### PR TITLE
disable ntp time check

### DIFF
--- a/usr/share/i2p/router.config.anondist
+++ b/usr/share/i2p/router.config.anondist
@@ -21,3 +21,4 @@ routerconsole.country=
 routerconsole.lang=en
 router.updateDisabled=true
 routerconsole.welcomeWizardComplete=true
+time.disabled=true


### PR DESCRIPTION
disabled time check since it uses ntp which doesnt exist in whonix. (it has no effect on the connection)