### PR TITLE
Disable Frequent connection to news letter server

### DIFF
--- a/usr/share/i2p/router.config.anondist
+++ b/usr/share/i2p/router.config.anondist
@@ -21,5 +21,6 @@ router.sharePercentage=0
 routerconsole.country=
 routerconsole.lang=en
 router.updateDisabled=true
+router.newsRefreshFrequency=-1
 routerconsole.welcomeWizardComplete=true
 time.disabled=true


### PR DESCRIPTION
No need to make unnecessary connections to external server for each couple of minutes. Harmful anonymity practice.